### PR TITLE
Fix getting the file origin

### DIFF
--- a/src/ScriptExtenderPluginChecker.py
+++ b/src/ScriptExtenderPluginChecker.py
@@ -17,7 +17,7 @@ class PluginMessage():
     def __init__(self, pluginPath, organizer):
         self._pluginPath = Path(pluginPath)
         try:
-            self._pluginOrigin = organizer.getFileOrigins(str(self._pluginPath.relative_to(organizer.managedGame().dataDirectory().absolutePath())))[-1]
+            self._pluginOrigin = organizer.getFileOrigins(str(self._pluginPath.relative_to(organizer.managedGame().dataDirectory().absolutePath())))[0]
         except:
             self._pluginOrigin = PluginMessage.kUnknownOrigin
 
@@ -162,7 +162,7 @@ class ScriptExtenderPluginChecker(mobase.IPluginDiagnose):
         return self.__tr("Checks script extender log to see if any plugins failed to load.")
 
     def version(self):
-        return mobase.VersionInfo(1, 0, 0, mobase.ReleaseType.prealpha)
+        return mobase.VersionInfo(1, 0, 1, 0)
 
     def isActive(self):
         return ( self.__organizer.managedGame().gameName() in self.supportedGames


### PR DESCRIPTION
The first entry in the list returned by getFileOrigins is always the
file origin.  Other entries in the list are alternatives in lower
priority mods.