### PR TITLE
Always open log files as cp1252

### DIFF
--- a/src/ScriptExtenderPluginChecker.py
+++ b/src/ScriptExtenderPluginChecker.py
@@ -228,7 +228,7 @@ class ScriptExtenderPluginChecker(mobase.IPluginDiagnose):
             gameLogPath = base / gameSuffix
             if gameLogPath.exists():
                 try:
-                    with gameLogPath.open('r') as logFile:
+                    with gameLogPath.open('r', encoding='cp1252') as logFile:
                         for line in logFile:
                             message = PluginMessage.PluginMessageFactory(line, self.__organizer)
                             if message:
@@ -242,7 +242,7 @@ class ScriptExtenderPluginChecker(mobase.IPluginDiagnose):
             editorLogPath = base / editorSuffix
             if editorLogPath.exists():
                 try:
-                    with editorLogPath.open('r') as logFile:
+                    with editorLogPath.open('r', encoding='cp1252') as logFile:
                         for line in logFile:
                             message = PluginMessage.PluginMessageFactory(line, self.__organizer)
                             if message:


### PR DESCRIPTION
Even if the system-default text encoding is something else, apparently script extender logs always use cp1252. Characters unsupported by cp1252 end up converted into their closest equivalent (or, in some cases, the same character with the accent removed - `ÿ` is `0xFF` in cp1252, but load a DLL with that in the name, and you'll get `y` in the log).

I'm still not 100% convinced that this is the right encoding (I'd really like the log from this guy that actually discovered the issue https://github.com/ModOrganizer2/modorganizer/issues/938) but I know it's definitely not supposed to be cp1251, and if it's UTF-8, there's some mangling going on earlier in the sequence.