### PR TITLE
Add non-failure status message to plugin checker

### DIFF
--- a/src/ScriptExtenderPluginChecker.py
+++ b/src/ScriptExtenderPluginChecker.py
@@ -60,7 +60,7 @@ class NormalPluginMessage(PluginMessage):
         self.__loadStatus = match.group("loadStatus")
 
     def successful(self):
-        return not self.valid() or self.__loadStatus == "loaded correctly"
+        return not self.valid() or self.__loadStatus == "loaded correctly" or self.__loadStatus == "no version data"
 
     def asMessage(self):
         return self.__tr("{0} version {1} ({2}, {4}) {3}.").format(self.__name, self.__version, self._pluginPath.name, self.__trLoadStatus(), self._pluginOrigin)

--- a/src/ScriptExtenderPluginChecker.py
+++ b/src/ScriptExtenderPluginChecker.py
@@ -86,7 +86,7 @@ class NormalPluginMessage(PluginMessage):
     def __tr(self, str):
         return QCoreApplication.translate("NormalPluginMessage", str)
 
-PluginMessage.registerMessageType((re.compile(r"plugin (?P<pluginPath>.+) \((?P<infoVersion>[\dA-Fa-f]{8}) (?P<name>.+) (?P<version>[\dA-Fa-f]{8})\) (?P<loadStatus>.+?)( \(handle \d+\))?\s$"), NormalPluginMessage))
+PluginMessage.registerMessageType((re.compile(r"plugin (?P<pluginPath>.+) \((?P<infoVersion>[\dA-Fa-f]{8}) (?P<name>.*) (?P<version>[\dA-Fa-f]{8})\) (?P<loadStatus>.+?)(?P<errorCode> \d+)?( \(handle \d+\))?\s$"), NormalPluginMessage))
 
 
 class CouldntLoadPluginMessage(PluginMessage):

--- a/src/ScriptExtenderPluginChecker.py
+++ b/src/ScriptExtenderPluginChecker.py
@@ -69,12 +69,19 @@ class NormalPluginMessage(PluginMessage):
         # We need to list the possible options so they get detected as translatable strings.
         loadStatusTranslations = {
             "loaded correctly" : self.__tr("loaded correctly"),
+            # Messages taken from SKSE64 2.1.3
+            "disabled, address library needs to be updated" : self.__tr("disabled, address library needs to be updated"),
+            "disabled, fatal error occurred while loading plugin" : self.__tr("disabled, fatal error occurred while loading plugin"),
+            "disabled, bad version data" : self.__tr("disabled, bad version data"),
+            "disabled, no name specified" : self.__tr("disabled, no name specified"),
+            "disabled, unsupported version independence method" : self.__tr("disabled, unsupported version independence method"),
+            "disabled, incompatible with current runtime version" : self.__tr("disabled, incompatible with current runtime version"),
+            "disabled, requires newer script extender" : self.__tr("disabled, requires newer script extender"),
+            # Legacy messages
             "reported as incompatible during query" : self.__tr("reported as incompatible during query"),
             "reported as incompatible during load" : self.__tr("reported as incompatible during load"),
-            "disabled, fatal error occurred while loading plugin" : self.__tr("disabled, fatal error occurred while loading plugin"),
-            "disabled, no name specified" : self.__tr("disabled, no name specified"),
             "disabled, fatal error occurred while checking plugin compatibility" : self.__tr("disabled, fatal error occurred while checking plugin compatibility"),
-            "disabled, fatal error occurred while querying plugin" : self.__tr("disabled, fatal error occurred while querying plugin")
+            "disabled, fatal error occurred while querying plugin" : self.__tr("disabled, fatal error occurred while querying plugin"),
         }
         if self.__loadStatus in loadStatusTranslations:
             return loadStatusTranslations[self.__loadStatus]


### PR DESCRIPTION
SKSE 2.1.3 adds some new error reporting for plugins. Most of it was designed to be backwards compatible, but a non-failure status is now reported in the log for DLLs that don't look like SKSE plugins (can happen in legit cases for dependent DLLs).

Example line: `plugin avcodec-58.dll (00000000  00000000) no version data 0 (handle 0)`
